### PR TITLE
remove the randomness of CSF implementation

### DIFF
--- a/code/3rd_party/csf/Cloth.cpp
+++ b/code/3rd_party/csf/Cloth.cpp
@@ -102,9 +102,7 @@ double Cloth::timeStep() {
     for (int i = 0; i < particleCount; i++) {
         particles_[i].timeStep();
     }
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
+
     for (int j = 0; j < particleCount; j++) {
         particles_[j].satisfyConstraintSelf(constraint_iterations_);
     }


### PR DESCRIPTION
If you use OpenMP in CSF module, you will get a random mesh. So we remove the randomness of it.